### PR TITLE
Typo in Rect Extensions

### DIFF
--- a/Assets/Etra Games/Etra'sStarterAssets/2-Source/Editor/RectExtensions.cs
+++ b/Assets/Etra Games/Etra'sStarterAssets/2-Source/Editor/RectExtensions.cs
@@ -42,7 +42,7 @@ namespace Etra.StarterAssets.Source.Editor
             return r;
         }
 
-        public static Rect ResizeWHeightToCenter(this Rect r, float height)
+        public static Rect ResizeHeightToCenter(this Rect r, float height)
         {
             r.y += (r.height - height) / 2f;
             r.height = height;


### PR DESCRIPTION
I've renamed `ResizeWHeightToCenter` to `ResizeHeightToCenter` and I believe this change will improve the quality of the Starter Assets quite greatly.